### PR TITLE
LargeNgramList - add support for parsing large files

### DIFF
--- a/conf-sample.json
+++ b/conf-sample.json
@@ -6,5 +6,7 @@
   "ngramIgnoreStrings": ["\"", ","],
   "matchPrefixWords": ["t", "i", "m"],
   "outDirectory": "/home/tomas/work/data/ngramy/syn_v4",
-  "minNgramFreq": 4
+  "minNgramFreq": 4,
+  "tmpDir": "/tmp/gloomy",
+  "procChunkSize": 1000000
 }

--- a/index/builder/ngramlist.go
+++ b/index/builder/ngramlist.go
@@ -15,12 +15,14 @@
 package builder
 
 import (
+	"fmt"
+
 	"github.com/tomachalek/gloomy/index/column"
 )
 
 func ngramsCmp(n1 []string, n2 []string) int {
 	if len(n1) != len(n2) {
-		panic("Cannot compare ngrams of different sizes")
+		panic(fmt.Sprintf("Cannot compare ngrams of different sizes (%d vs. %d)", len(n1), len(n2)))
 	}
 	for i := 0; i < len(n1); i++ {
 		if n1[i] > n2[i] {
@@ -49,32 +51,32 @@ func (n *NgramNode) GetNgram() []string {
 	return n.ngram
 }
 
-type NgramList struct {
+type RAMNgramList struct {
 	root     *NgramNode
 	numNodes int
 }
 
-func dfsWalkthruRecursive(node *NgramNode, fn func(n *NgramNode)) {
+func dfsWalkthruRecursive(node *NgramNode, fn func(n *NgramRecord)) {
 	if node.left != nil {
 		dfsWalkthruRecursive(node.left, fn)
 	}
-	fn(node)
+	fn(&NgramRecord{Ngram: node.ngram, Count: node.count, Args: node.args})
 	if node.right != nil {
 		dfsWalkthruRecursive(node.right, fn)
 	}
 }
 
-func (n *NgramList) DFSWalkthru(fn func(n *NgramNode)) {
+func (n *RAMNgramList) ForEach(fn func(n *NgramRecord)) {
 	if n.root != nil {
 		dfsWalkthruRecursive(n.root, fn)
 	}
 }
 
-func (n *NgramList) Size() int {
+func (n *RAMNgramList) Size() int {
 	return n.numNodes
 }
 
-func (n *NgramList) Add(ngram []string, metadata []column.AttrVal) {
+func (n *RAMNgramList) Add(ngram []string, metadata []column.AttrVal) {
 	if n.root == nil {
 		n.root = &NgramNode{ngram: ngram, count: 1, args: metadata}
 		n.numNodes = 1

--- a/index/builder/ngramlistLarge.go
+++ b/index/builder/ngramlistLarge.go
@@ -1,0 +1,197 @@
+// Copyright 2017 Tomas Machalek <tomas.machalek@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/tomachalek/gloomy/index/column"
+	"github.com/tomachalek/gloomy/util"
+)
+
+// ----------------------------------------------------
+
+type chunkReader struct {
+	path     string
+	file     *os.File
+	reader   *bufio.Reader
+	decoder  *gob.Decoder
+	buffer   bytes.Buffer
+	currItem *NgramRecord
+	finished bool
+}
+
+func (ch *chunkReader) readNext() {
+	var ans NgramRecord
+	err := ch.decoder.Decode(&ans)
+	if err == io.EOF {
+		ch.finished = true
+
+	} else if err != nil {
+		log.Print("Failed to decode ngramRecord", err)
+
+	} else {
+		ch.currItem = &ans
+	}
+}
+
+func (ch *chunkReader) hasNext() bool {
+	return !ch.finished
+}
+
+func (ch *chunkReader) getCurrent() *NgramRecord {
+	return ch.currItem
+}
+
+func newChunkReader(path string) (*chunkReader, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	reader := bufio.NewReader(f)
+	ans := &chunkReader{
+		path:     path,
+		file:     f,
+		reader:   reader,
+		finished: false,
+	}
+	ans.decoder = gob.NewDecoder(reader)
+	return ans, nil
+}
+
+// ----------------------------------------------------
+
+type LargeNgramList struct {
+	currNgramList  *RAMNgramList
+	workingDirPath string
+	chunks         []string
+	chunkSize      int
+}
+
+func NewLargeNgramList(workingDirPath string, chunkSize int) *LargeNgramList {
+	if !util.IsDir(workingDirPath) {
+		err := os.MkdirAll(workingDirPath, os.ModePerm)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return &LargeNgramList{
+		currNgramList:  &RAMNgramList{},
+		workingDirPath: workingDirPath,
+		chunks:         make([]string, 0, 10),
+		chunkSize:      chunkSize,
+	}
+}
+
+func (nn *LargeNgramList) Size() int {
+	return nn.currNgramList.Size()
+}
+
+func (nn *LargeNgramList) Add(ngram []string, metadata []column.AttrVal) {
+	nn.currNgramList.Add(ngram, metadata)
+	if nn.currNgramList.Size() >= nn.chunkSize {
+		nn.saveChunk()
+		nn.currNgramList = &RAMNgramList{}
+	}
+}
+
+func (nn *LargeNgramList) generateNewChunkFileName() string {
+	return filepath.Join(nn.workingDirPath, fmt.Sprintf("chunk-%03d", len(nn.chunks)))
+}
+
+func (nn *LargeNgramList) saveChunk() error {
+	chunkPath := nn.generateNewChunkFileName()
+	f, err := os.OpenFile(chunkPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0664)
+	defer f.Close()
+	if err != nil {
+		return err
+	}
+	fw := bufio.NewWriter(f)
+	defer fw.Flush()
+
+	enc := gob.NewEncoder(fw)
+	nn.currNgramList.ForEach(func(n *NgramRecord) {
+		err := enc.Encode(n)
+		if err != nil {
+			log.Print("Failed to encode record")
+		}
+	})
+	nn.chunks = append(nn.chunks, chunkPath)
+	return nil
+}
+
+func findFirstNonEmptyReader(readers []*chunkReader) *chunkReader {
+	for _, v := range readers {
+		if v.hasNext() {
+			return v
+		}
+	}
+	return nil
+}
+
+func (nn *LargeNgramList) findSmallestNgram(readers []*chunkReader) *NgramRecord {
+	smallestIdx := 0
+	firstReader := findFirstNonEmptyReader(readers)
+	if firstReader == nil {
+		return nil
+	}
+	smallestRec := firstReader.getCurrent()
+	for i := 1; i < len(readers); i++ {
+		if !readers[i].hasNext() {
+			continue
+		}
+		switch ngramsCmp(readers[i].getCurrent().Ngram, smallestRec.Ngram) {
+		case -1:
+			smallestIdx = i
+			smallestRec = readers[i].getCurrent()
+		case 0:
+			smallestRec.Count += readers[i].getCurrent().Count
+			if readers[i].hasNext() {
+				readers[i].readNext()
+			}
+		}
+	}
+	if readers[smallestIdx].hasNext() {
+		readers[smallestIdx].readNext()
+	}
+	return smallestRec
+}
+
+func (nn *LargeNgramList) ForEach(fn func(n *NgramRecord)) {
+	if nn.currNgramList.Size() > 0 {
+		nn.saveChunk()
+	}
+	readers := make([]*chunkReader, len(nn.chunks))
+	var err error
+	for i, c := range nn.chunks {
+		readers[i], err = newChunkReader(c)
+		if err != nil {
+			panic(err) // TODO
+		}
+		readers[i].readNext() // read 1st item
+	}
+
+	var curr *NgramRecord
+	for curr = nn.findSmallestNgram(readers); curr != nil; curr = nn.findSmallestNgram(readers) {
+		fn(curr)
+	}
+}

--- a/index/extras/extras.go
+++ b/index/extras/extras.go
@@ -17,20 +17,21 @@ package extras
 import (
 	"bufio"
 	"fmt"
-	"github.com/tomachalek/gloomy/index/builder"
-	"github.com/tomachalek/gloomy/index/gconf"
-	"github.com/tomachalek/vertigo"
 	"log"
 	"os"
 	"strings"
+
+	"github.com/tomachalek/gloomy/index/builder"
+	"github.com/tomachalek/gloomy/index/gconf"
+	"github.com/tomachalek/vertigo"
 )
 
-func saveNgrams(ngramList *builder.NgramList, minFreq int, saveFile *os.File) error {
+func saveNgrams(ngramList builder.NgramList, minFreq int, saveFile *os.File) error {
 	fw := bufio.NewWriter(saveFile)
 	defer fw.Flush()
-	ngramList.DFSWalkthru(func(item *builder.NgramNode) {
-		if item.GetCount() >= minFreq {
-			fw.WriteString(fmt.Sprintf("%s\t%d\n", strings.Join(item.GetNgram(), "\t"), item.GetCount()))
+	ngramList.ForEach(func(item *builder.NgramRecord) {
+		if item.Count >= minFreq {
+			fw.WriteString(fmt.Sprintf("%s\t%d\n", strings.Join(item.Ngram, "\t"), item.Count))
 		}
 	})
 	return nil

--- a/index/gconf/gconf.go
+++ b/index/gconf/gconf.go
@@ -76,6 +76,10 @@ type IndexBuilderConf struct {
 	NgramMatchPrefix []string `json:"ngramMatchPrefix"`
 
 	UseStrictStructParser bool `json:"useStrictStructParser"`
+
+	TmpDir string `json:"tmpDir"`
+
+	ProcChunkSize int `json:"procChunkSize"`
 }
 
 func (i *IndexBuilderConf) GetParserConf() *vertigo.ParserConf {
@@ -115,7 +119,7 @@ type OutputFiles struct {
 
 func (o *OutputFiles) GetSortedIndexTmpPath(mode int) (*os.File, error) {
 	inFilenamePrefix := stripSuffix(filepath.Base(o.conf.InputFilePath))
-	fileName := fmt.Sprintf("%s_%d-grams.tmp", inFilenamePrefix, o.ngramSize)
+	fileName := fmt.Sprintf("%s_%d-grams.txt", inFilenamePrefix, o.ngramSize)
 	outPath := filepath.Join(o.indexDir, fileName)
 	return os.OpenFile(outPath, mode, o.filePerm)
 }

--- a/util/util.go
+++ b/util/util.go
@@ -14,6 +14,8 @@
 
 package util
 
+import "os"
+
 func FirstError(args ...error) error {
 	for _, err := range args {
 		if err != nil {
@@ -21,4 +23,16 @@ func FirstError(args ...error) error {
 		}
 	}
 	return nil
+}
+
+func IsDir(path string) bool {
+	f, err := os.Open(path)
+	if err != nil {
+		return false
+	}
+	finfo, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return finfo.Mode().IsDir()
 }


### PR DESCRIPTION
ngram list can be configured to keep only a single
chunk of data in ram and when full, save the chunk
to disk. Finally, all the chunks are merged.

(in-memory list can be still used)